### PR TITLE
Refactor wiki-reload

### DIFF
--- a/JumpscaleLibs/tools/markdowndocs/DocSite.py
+++ b/JumpscaleLibs/tools/markdowndocs/DocSite.py
@@ -662,7 +662,6 @@ class DocSite(j.baseclasses.object):
     def metadata_path(self):
         return self.outpath + "/.data"
 
-
     def write(self, reset=False):
         self.load()
         self.verify()
@@ -739,4 +738,3 @@ def prepare_name(name):
         raise j.exceptions.Base("name cannot be empty")
 
     return name
-

--- a/JumpscaleLibs/tools/markdowndocs/MarkDownDocs.py
+++ b/JumpscaleLibs/tools/markdowndocs/MarkDownDocs.py
@@ -232,8 +232,8 @@ class MarkDownDocs(j.baseclasses.object):
             # clean up deleted files
             for del_file in deleted_files:
                 if del_file != "":
-                    file_name = j.sal.fs.getBaseName(del_file).rstrip(".md")
-                    file_path = f"{docsite.path}/{file_name}"
+                    file_name = j.sal.fs.getBaseName(del_file)
+                    file_path = f"{docsite.outpath}/{file_name}"
                     if j.sal.bcdbfs.file_exists(file_path):
                         j.sal.bcdbfs.file_delete(file_path)
                         print(f"wiki: docsite.name, file: {del_file}. Deletion Success")

--- a/JumpscaleLibs/tools/markdowndocs/macros/slideshow_v2.py
+++ b/JumpscaleLibs/tools/markdowndocs/macros/slideshow_v2.py
@@ -143,4 +143,3 @@ def slideshow_v2(doc, **kwargs):
 
 
 # for future work we propose to use islice function to help in slicing
-


### PR DESCRIPTION
- Move wiki reload under `j.tools.markdown.reload`.
- Refactored the `Docsite` class and refactored the reload function accordingly to use the path attributes from the docsite object instead of having the same strings duplicated everywhere.
- Fixes update of the deleted files.

Fixes https://github.com/threefoldtech/jumpscaleX_threebot/issues/112 

Needs to be merged before https://github.com/threefoldtech/jumpscaleX_threebot/pull/145 and https://github.com/threefoldtech/jumpscaleX_core/pull/141 
