### PR TITLE
fix gdrive client and add gpdf macro

### DIFF
--- a/JumpscaleLibs/clients/gdrive/GDriveClient.py
+++ b/JumpscaleLibs/clients/gdrive/GDriveClient.py
@@ -55,7 +55,7 @@ class GDriveClient(JSConfigClient):
             file.exportPDF(path=destpath)
             return True
 
-        return self._cache.get("exportFile_{}".format(file_id), method=do, expire=300)
+        return self._cache.get("exportFile_{}_{}".format(file_id, destpath), method=do, expire=300)
 
     def exportSlides(self, presentation, destpath="/tmp", staticdir=None, size="MEDIUM"):
         def do():
@@ -79,7 +79,7 @@ class GDriveClient(JSConfigClient):
                 j.sal.fs.moveDir(presentation_dir, staticdir)
             return True
 
-        return self._cache.get("exportSlides_{}".format(presentation), method=do, expire=300)
+        return self._cache.get("exportSlides_{}_{}".format(presentation, destpath), method=do, expire=300)
 
     def export_slides_with_ranges(self, presentation, destpath="/tmp", staticdir=None, size="MEDIUM"):
         def do():

--- a/JumpscaleLibs/tools/markdowndocs/macros/gpdf.py
+++ b/JumpscaleLibs/tools/markdowndocs/macros/gpdf.py
@@ -1,0 +1,33 @@
+import re
+
+PDF_URL = {
+    "document": "https://docs.google.com/document/d/{file_id}/export?format=pdf",
+    "presentation": "https://docs.google.com/presentation/d/{file_id}/export/pdf",
+    "spreadsheets": "https://docs.google.com/spreadsheets/d/{file_id}/export?format=pdf",
+}
+
+ID_REGEX = r"([a-zA-Z]+)\/d\/([a-zA-Z0-9-_]+)"
+
+
+def gpdf(doc, link, **kwargs):
+    """generate pdf download link from google drive link to document or presentation
+
+    :param doc: current document
+    :type doc: Doc
+    :param link: full url of document or presentation
+    :type link: str
+    :return: a download link to document/presentation as pdf
+    :rtype: str
+    """
+    j = doc.docsite._j
+
+    link = link.strip()
+    match = re.search(ID_REGEX, link)
+    if match:
+        doc_type, file_id = match.groups()
+        if doc_type not in PDF_URL:
+            raise j.exceptions.Value(f"{doc_type} is not a supported document type")
+
+        pdf_link = PDF_URL[doc_type].format(file_id=file_id)
+        return f"[download as pdf]({pdf_link})"
+    raise j.exceptions.Value(f"cannot extract document type of id from an invalid link '{link}''")

--- a/JumpscaleLibs/tools/markdowndocs/macros/gpdf.py
+++ b/JumpscaleLibs/tools/markdowndocs/macros/gpdf.py
@@ -1,12 +1,7 @@
 import re
 
-PDF_URL = {
-    "document": "https://docs.google.com/document/d/{file_id}/export?format=pdf",
-    "presentation": "https://docs.google.com/presentation/d/{file_id}/export/pdf",
-    "spreadsheets": "https://docs.google.com/spreadsheets/d/{file_id}/export?format=pdf",
-}
 
-ID_REGEX = r"([a-zA-Z]+)\/d\/([a-zA-Z0-9-_]+)"
+DOC_INFO_REGEX = r"([a-zA-Z]+)\/d\/([a-zA-Z0-9-_]+)"
 
 
 def gpdf(doc, link, **kwargs):
@@ -22,12 +17,16 @@ def gpdf(doc, link, **kwargs):
     j = doc.docsite._j
 
     link = link.strip()
-    match = re.search(ID_REGEX, link)
+    match = re.search(DOC_INFO_REGEX, link)
     if match:
         doc_type, file_id = match.groups()
-        if doc_type not in PDF_URL:
-            raise j.exceptions.Value(f"{doc_type} is not a supported document type")
+        if doc_type not in ("document", "spreadsheets", "presentation"):
+            raise j.exceptions.Value(f"{doc_type} is not a supported document type ()")
 
-        pdf_link = PDF_URL[doc_type].format(file_id=file_id)
-        return f"[download as pdf]({pdf_link})"
+        pdf_link = f"/wiki/gdrive/{doc_type}/{file_id}"
+        # normal markdown links will be resolved by docsify, won't work
+        return f"""```inline_html
+            <a href="{pdf_link}">download as pdf</a>
+        ```
+        """
     raise j.exceptions.Value(f"cannot extract document type of id from an invalid link '{link}''")


### PR DESCRIPTION
gdrive client caches the operation with only file id, but if the `destpath` is different, it would fail as it cannot find the new destpath yet!