### PR TITLE
Stellar payment integration

### DIFF
--- a/JumpscaleLibs/sal/zosv2/billing.py
+++ b/JumpscaleLibs/sal/zosv2/billing.py
@@ -29,12 +29,12 @@ class Billing:
         rp = ResourceParser(self._explorer, reservation)
         return rp.calculate_used_resources_cost()
 
-    def payout_farmers(self, tfchain_wallet, reservation):
+    def payout_farmers(self, client, reservation):
         """
         payout farmer based on the resources per node used
 
-        :param tfchain_wallet: tfchain wallet
-        :type tfchain_wallet: a wallet of j.clients.tfchain
+        :param client: tfchain wallet or stellar client
+        :type client: a wallet of j.clients.tfchain or a client of j.client.stellar
         :param reservation: reservation object
         :type reservation: tfgrid.workloads.reservation.1
         :return: list of transactions
@@ -42,18 +42,18 @@ class Billing:
         """
         rp = ResourceParser(self._explorer, reservation)
         costs = rp.calculate_used_resources_cost()
-        return rp.payout_farmers(tfchain_wallet, costs, reservation.id)
+        return rp.payout_farmers(client, costs, reservation.id)
 
-    def verify_payments(self, tfchain_wallet, reservation):
+    def verify_payments(self, client, reservation):
         """
         verify that a reservation with a given ID has been paid for, for all farms belonging to the current user 3bot
 
-        :param tfchain_wallet: tfchain wallet
-        :type tfchain_wallet: a wallet of j.clients.tfchain
+        :param client: tfchain wallet or stellar client
+        :type client: a wallet of j.clients.tfchain or a client of j.client.stellar
         :param reservation: reservation object
         :type reservation: tfgrid.workloads.reservation.1
         :return: if the reservation has been fully funded for the farms owned by the current user 3bot
         :rtype: bool
         """
         rp = ResourceParser(self._explorer, reservation)
-        return rp.validate_reservation_payment(tfchain_wallet, reservation.id)
+        return rp.validate_reservation_payment(client, reservation.id)

--- a/JumpscaleLibs/sal/zosv2/readme.md
+++ b/JumpscaleLibs/sal/zosv2/readme.md
@@ -212,13 +212,16 @@ costs = zos.billing.reservation_resources_cost(reservation)
 for cost in costs:
     print(cost)
 
-# to be able to send tokens to the farmers, a TFChain wallet needs to be available on the system
-client = j.clients.tfchain.get('myclient')
-wallet = client.wallets.get("default")
+# to be able to send tokens to the farmers, a TFChain wallet or Stellar client needs to be available on the system
+tfchain = j.clients.tfchain.get('myclient')
+client = tfchain.wallets.get("default")
+
+# or use the stellar client
+client = j.clients.stellar.get('myclient')
 
 # once we have verified everything is in order, we create the transaction
 # to send the token to the farms
-transactions = zos.billing.payout_farmers(wallet, costs, reservation)
+transactions = zos.billing.payout_farmers(client, costs, reservation)
 # if everything went ok, at this point your transaction are now sent to the blockchain
 ```
 
@@ -228,11 +231,14 @@ transactions = zos.billing.payout_farmers(wallet, costs, reservation)
 zos = j.sal.zosv2
 
 
-client = j.clients.tfchain.get('myclient')
-wallet = client.wallets.get("default")
+tfchain = j.clients.tfchain.get('myclient')
+client = tfchain.wallets.get("default")
+
+# or use the stellar client
+client = j.clients.stellar.get('myclient')
 
 # the farmer needs to know the reservation ID to be able to check if the payment has arrived for it
 reservation = zos.reservation_get(reservation_id)
 # verify_payments will return true if everything has been paid or false if not
-zos.billing.verify_payments(wallet, reservation)
+zos.billing.verify_payments(client, reservation)
 ```

--- a/JumpscaleLibs/sal/zosv2/resource.py
+++ b/JumpscaleLibs/sal/zosv2/resource.py
@@ -1,5 +1,8 @@
 from Jumpscale import j
 from decimal import Decimal, getcontext
+from stellar_sdk.exceptions import BadRequestError
+
+FARMER_STELLAR_ADDRESS = "GDSDHVHBB53Q36ZR4HQVXQAGDQPZXPAGZ5HOQBHDX2IUGXNLU5E4SPCO"
 
 
 class ResourceParser:
@@ -47,7 +50,6 @@ class ResourceParser:
             farm = self._actor_directory.farms.get(node.farm_id, False)
 
             wallet_address = farm.wallet_addresses[0]
-
             total_cru_cost = resource_unit_node.CRU * farm.resource_prices[0].cru
             total_sru_cost = resource_unit_node.SRU * farm.resource_prices[0].sru
             total_hru_cost = resource_unit_node.HRU * farm.resource_prices[0].hru
@@ -65,7 +67,15 @@ class ResourceParser:
 
         return resource_units_per_node
 
-    def payout_farmers(self, tfchain_wallet, resource_units_per_node, reservation_id):
+    def payout_farmers(self, client, resource_units_per_node, reservation_id):
+        if client._classname == "tfchainwallet":
+            _payout_farmers_tfchain(self, client, resource_units_per_node, reservation_id)
+        elif client._classname == "stellarclient":
+            _payout_farmers_stellar(self, client, resource_units_per_node, reservation_id)
+        else:
+            raise j.exceptions.Value("Provided client or wallet is not supported.")
+
+    def _payout_farmers_tfchain(self, tfchain_wallet, resource_units_per_node, reservation_id):
         total = Decimal(sum([c.TOTAL_COST for c in resource_units_per_node]))
         available = tfchain_wallet.balance.available.value
         if available < total:
@@ -86,7 +96,45 @@ class ResourceParser:
                 continue
         return transactions
 
-    def validate_reservation_payment(self, tfchain_wallet, reservation_id):
+    def _payout_farmers_stellar(self, client, resource_units_per_node, reservation_id):
+        total = Decimal(sum([c.TOTAL_COST for c in resource_units_per_node]))
+        available_balance = None
+        for balance in client.get_balance():
+            if not balance.is_native():
+                available_balance = balance.balance
+
+        if available_balance is None:
+            raise j.exceptions.Value("No balance in TFT has been found")
+
+        if available_balance < total:
+            err_msg = f"not enough found in the wallet to pay the reservation\nHave {available_balance}, needs {total}"
+            raise j.exceptions.Value(err_msg)
+
+        transactions = []
+        for resource_unit_node in resource_units_per_node:
+            resource_unit_node.workload_id.sort()
+            workload_ids = [str(wid) for wid in resource_unit_node.workload_id]
+            msg = "-".join(workload_ids)
+            msg = "{}-{}".format(reservation_id, msg)
+            try:
+                # txn = client.transfer(resource_unit_node.farm_wallet, str(resource_unit_node.TOTAL_COST), memo_text=msg)
+
+                txn = client.transfer(FARMER_STELLAR_ADDRESS, str(resource_unit_node.TOTAL_COST), memo_text=msg)
+                transactions.append(txn)
+                continue
+            except BadRequestError as e:
+                raise e
+        return transactions
+
+    def validate_reservation_payment(self, wallet, reservation_id):
+        if client._classname == "tfchainwallet":
+            _validate_reservation_payment_tfchain(self, client, resource_units_per_node, reservation_id)
+        elif client._classname == "stellarclient":
+            _validate_reservation_payment_stellar(self, client, resource_units_per_node, reservation_id)
+        else:
+            raise j.exceptions.Value("Provided client or wallet is not supported.")
+
+    def _validate_reservation_payment_tfchain(self, wallet, reservation_id):
         getcontext().prec = 9
         me_tid = j.tools.threebot.me.default.tid
         # load all farms belonging to our threebot id
@@ -119,7 +167,42 @@ class ResourceParser:
                     if amount == str(value):
                         # good tx, remove from expected set
                         expected_txes.remove((msg, amount))
-        # verification is now done, if teh expected tx set is empty, it means
+        # verification is now done, if the expected tx set is empty, it means
+        # all required txes have been created and processed.
+        return len(expected_txes) == 0
+
+    def _validate_reservation_payment_stellar(self, client, reservation_id):
+        getcontext().prec = 7
+        # me_tid = j.tools.threebot.me.default.tid
+        me_tid = 1
+        # load all farms belonging to our threebot id
+        farms = self._actor_directory.farms.owned_by(me_tid).farms
+        farm_ids = set()
+        for farm in farms:
+            farm_ids.add(farm.id)
+        # load reservation and parse resource units
+        resource_units_per_node = self.calculate_used_resources_cost()
+        # tuple of the message and amount expected in a tx
+        expected_txes = set()
+        for resource_unit_node in resource_units_per_node:
+            if resource_unit_node.farm_id in farm_ids:
+                resource_unit_node.workload_id.sort()
+                workload_ids = [str(wid) for wid in resource_unit_node.workload_id]
+                msg = "-".join(workload_ids)
+                msg = "{}-{}".format(reservation_id, msg)
+                amount = Decimal(resource_unit_node.TOTAL_COST)
+                expected_txes.add((msg, amount))
+        # load the transactions in our wallet, for every workload in one of the owned farms, whe need a trandaction
+        # with the right amount of tft
+        for tx in client.list_transactions():
+            for (msg, amount) in expected_txes:
+                if msg == tx.memo_text:
+                    # verify amount
+                    txe = client.get_transaction_effects(tx.hash)[0]
+                    if txe.amount == value:
+                        # good tx, remove from expected set
+                        expected_txes.remove((msg, amount))
+        # verification is now done, if the expected tx set is empty, it means
         # all required txes have been created and processed.
         return len(expected_txes) == 0
 

--- a/JumpscaleLibs/sal/zosv2/resource.py
+++ b/JumpscaleLibs/sal/zosv2/resource.py
@@ -1,6 +1,8 @@
 from Jumpscale import j
 from decimal import Decimal, getcontext
 from stellar_sdk.exceptions import BadRequestError
+from JumpscaleLibs.clients.stellar.StellarClient import StellarClient
+from JumpscaleLibs.clients.tfchain.TFChainWallet import TFChainWallet
 
 # TFT_ISSUER on production
 TFT_ISSUER_PROD = "GBOVQKJYHXRR3DX6NOX2RRYFRCUMSADGDESTDNBDS6CDVLGVESRTAC47"
@@ -72,9 +74,9 @@ class ResourceParser:
         return resource_units_per_node
 
     def payout_farmers(self, client, resource_units_per_node, reservation_id):
-        if client._classname == "tfchainwallet":
+        if isinstance(client, TFChainWallet):
             self._payout_farmers_tfchain(client, resource_units_per_node, reservation_id)
-        elif client._classname == "stellarclient":
+        if isinstance(client, StellarClient):
             self._payout_farmers_stellar(client, resource_units_per_node, reservation_id)
         else:
             raise j.exceptions.Value("Provided client or wallet is not supported.")
@@ -137,9 +139,9 @@ class ResourceParser:
         return transactions
 
     def validate_reservation_payment(self, client, reservation_id):
-        if client._classname == "tfchainwallet":
+        if isinstance(client, TFChainWallet):
             return self._validate_reservation_payment_tfchain(client, reservation_id)
-        elif client._classname == "stellarclient":
+        if isinstance(client, StellarClient):
             return self._validate_reservation_payment_stellar(client, reservation_id)
         else:
             raise j.exceptions.Value("Provided client or wallet is not supported.")

--- a/JumpscaleLibs/sal/zosv2/resource.py
+++ b/JumpscaleLibs/sal/zosv2/resource.py
@@ -165,7 +165,8 @@ class ResourceParser:
             for co in tx.coin_outputs:
                 if co.condition.unlockhash in tfchain_wallet.addresses:
                     value += co.value.value
-            for (msg, amount) in expected_txes:
+            expected_txes_copy = expected_txes.copy()
+            for (msg, amount) in expected_txes_copy:
                 if msg == tx.data.value.decode():
                     # verify amount
                     if amount == str(value):


### PR DESCRIPTION
Refactored the payment flow to also accept a stellar client.

Parameter is now client:
- Can be a Tfchain wallet client
- Can be a Stellar client

Note the difference is that with Tfchain you provide the wallet client (because we cannot infer this from the parent tfchain client) and with Stellar you just provide the client (there are no wallet clients there).

Based on this parameter it's either going to transfer Tfchain TFT's or Stellar TFT's. The same goes for the farmer if he wishes to check if the payment was made.

NOTE:
- If you for example provide a Stellar client but the address of the farm is a Tfchain address, payment wont work!! Same goes for the reverse.
- Stellar: right now the sender and receiver (sender is client and receiver is farmer), need to have a trustline set to the Issuer of the Stellar asset! Else payments wont work (to set a trustline check: https://github.com/threefoldtech/jumpscaleX_libs/tree/development/JumpscaleLibs/clients/stellar#trustlines)
- Stellar: right now it is only possible to test this payment flow with real production TFT's on Stellar! I want to add some sort of test flag that can specify if we want to use this method for testing purposes so that the Asset Issuer can be set to the one we use for Stellar Testnet. More on that: https://github.com/threefoldfoundation/tft-stellar#testnet