### PR TITLE
Add logs to zosv2 container, and to reservation container schema

### DIFF
--- a/JumpscaleLibs/clients/explorer/models/tfgrid_workloads_reservation_container_1.toml
+++ b/JumpscaleLibs/clients/explorer/models/tfgrid_workloads_reservation_container_1.toml
@@ -23,6 +23,7 @@ network_connection = (LO) !tfgrid.workloads.reservation.network.connection.1
 stats_aggregator = (LO) !tfgrid.workloads.reservation.statsaggregator.1
 #id of threebot who is the farmer
 farmer_tid = (I)
+logs = (LO) !tfgrid.workloads.reservation.container.logs.1
 capacity = (O) !tfgrid.workloads.reservation.container.capacity.1
 
 
@@ -35,6 +36,14 @@ mountpoint = (S)
 network_id = (S)
 ipaddress = (ipaddress)
 public_ip6 = (B)
+
+@url = tfgrid.workloads.reservation.container.logs.1
+type = (S)
+data = (O) !tfgrid.workloads.reservation.container.logsredis.1
+
+@url = tfgrid.workloads.reservation.container.logsredis.1
+stdout = (S)
+stderr = (S)
 
 @url = tfgrid.workloads.reservation.container.capacity.1
 # Number of vCPU

--- a/JumpscaleLibs/sal/reservation_chatflow/reservation_chatflow.py
+++ b/JumpscaleLibs/sal/reservation_chatflow/reservation_chatflow.py
@@ -827,6 +827,7 @@ class Chatflow(j.baseclasses.object):
             "kubernetes": "tfgrid.solutions.kubernetes.1",
             "network": "tfgrid.solutions.network.1",
             "gitea": "tfgrid.solutions.gitea.1",
+            "monitoring": "tfgrid.solutions.monitoring.1",
         }
 
         for _, url in urls.items():

--- a/JumpscaleLibs/sal/zosv2/container.py
+++ b/JumpscaleLibs/sal/zosv2/container.py
@@ -84,3 +84,10 @@ class ContainerGenerator:
         result = box.encrypt(value.encode())
 
         return binascii.hexlify(result).decode()
+
+    def add_logs(self, cont, channel_type, channel_host, channel_port, channel_name):
+        cont_logs = cont.logs.new()
+        cont_logs.type = channel_type
+        cont_logs.data.stdout = f"redis://{channel_host}:{channel_port}/{channel_name}-stdout"
+        cont_logs.data.stderr = f"redis://{channel_host}:{channel_port}/{channel_name}-stderr"
+        return cont_logs


### PR DESCRIPTION
- Add logs to reservation container schema `tfgrid.workloads.reservation.container.1`
- Add `add_logs()` to zosv2 container to add logs to container instance of a reservation
- Add monitoring chatflow schema usage in solutions_explorer_get() of reservation chatflow sal

https://github.com/threefoldtech/home/issues/761